### PR TITLE
#26/base path

### DIFF
--- a/data/dp2-tabular/data2.csv
+++ b/data/dp2-tabular/data2.csv
@@ -1,0 +1,4 @@
+year,title,director
+1964,Dr. Strangelove or: How I Learned to Stop Worrying and Love the Bomb,Stanley Kubrick
+2004,"Spring, Summer, Fall, Winter... and Spring",Kim Ki-duk
+2006,Inland Empire,David Lynch

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import Datapackage from './datapackage'
 import Resource from './resource'
 import Profiles from './profiles'
 import validate from './validate'

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,17 +1,19 @@
-
 import url from 'url'
 import jts from 'jsontableschema'
 import _ from 'lodash'
+import path from 'path'
 
-/**
- * Base class for all Data Package's resource types.
- *
- * @returns {Resource}
- */
+/* Base class for all Data Package's resource types. */
 export default class Resource {
-
-  constructor(descriptor) {
+  /**
+   * Create a Resource instance.
+   *
+   * @param {Object} descriptor
+   * @param {String} [basePath=null]
+   */
+  constructor(descriptor, basePath = null) {
     this._descriptor = descriptor
+    this._basePath = basePath
     this.REMOTE_PROTOCOLS = ['http:', 'https:', 'ftp:', 'ftps:']
   }
 
@@ -56,11 +58,18 @@ export default class Resource {
 
   /**
    * Returns the path where data is located or
-   * if the data is inline it returns the actual data
+   * if the data is inline it returns the actual data.
+   * If the source is a path, the basepath is prepended
+   * if provided on Resource initialization.
    *
    * @returns {String|Array|Object}
    */
   get source() {
+    if (this._sourceKey === 'path' && this._basePath) {
+      const resourcePath = this.descriptor[this._sourceKey]
+      return path.normalize(`${this._basePath}/${resourcePath}`)
+    }
+
     return this.descriptor[this._sourceKey]
   }
 

--- a/test/resource.js
+++ b/test/resource.js
@@ -3,6 +3,7 @@ import { assert } from 'chai'
 import jts from 'jsontableschema'
 import Resource from '../src/resource'
 import _ from 'lodash'
+import path from 'path'
 
 import dp1 from '../data/dp1/datapackage.json'
 
@@ -90,6 +91,23 @@ describe('Resource', () => {
        let table = await resource.table
        assert(table === null, 'Returned value not null')
      })
+
+  describe('_basePath', () => {
+    it('accepts a basePath', () => {
+      const basePath = 'data/dp1'
+        , resource = new Resource(dp1.resources[0], basePath)
+        , resourceBasePath = resource.source
+
+      assert(path.dirname(resourceBasePath) === path.normalize(basePath), 'Incorrect base path')
+    })
+
+    it('_basePath is `null` if basePath argument is not provided', () => {
+      const resource = new Resource({})
+        , source = resource._basePath
+
+      assert(source === null, 'basePath not `null`')
+    })
+  })
 
   describe('Tests with dp1 from data', () => {
     let dpResources = []


### PR DESCRIPTION
Fixes #26

With this PR, a `basePath` can be specified when creating a Resource which defaults to `null`.

Also, when working with the Datapackage class, a basePath can be specified. If not specified and the descriptor is a local path, the dirname of the descriptor path is used as the basePath. This makes sense because as per Datapackage specs, resources location can't be behind the `datapackage.json` directory in the directory tree (nor the URI can contain `..`).