### PR TITLE
#41 table relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,19 @@ new Datapackage('http://bit.do/datapackage-json', 'base', false).then(datapackag
  - **profile** (defaults to `base`) is the validation profile to validate the descriptor against. Available profiles are `base`, `tabular` and `fiscal`, but you can also provide your own profile Object for validation.
  - **raiseInvalid** (defaults to `true`) can be used to specify if you want a Array of descriptive errors to be throws if the datapacakge is invalid (or becomes invalid after modifying it), or to be able to work with datapackage which is in invalid state.
  - **remoteProfiles** (defaults to `false`) can be used to specify if you want to work with the local copies of the profiles or fetch the latest profiles from Internet.
- - **basePath** (defaults to `null`if the descriptor is an Object or a remote path, or it's the `dirname` of the local path) can be used to specify the base path for the resources defined in the descriptor. For example if the resource path is `data/resource.cvs` and the `basePath` is set to `datapackages/dp1` the resources are expected to be in `datapackages/dp1/data/resource.cvs` relative of the directory where the library is executed.
+ - **basePath** (defaults to empty string if the descriptor is an Object, the URL if it's a remote path or it's the `dirname` of the local path) can be used to specify the base path for the resources defined in the descriptor. Resources path is always appended to the `basePath`. The default behaviour of `basePath` is:
+   - If initialized with path to a local file
+     - default `basePath` is `dirname` of the path
+     - any explicitly provided `basePath` to the constructor is appended to the default `basepath`
+   - If initialized with a remote path
+     - default `basePath` is the remote path
+     - any explicitly provided `basePath` to the constructor is appended to the default `basePath`
+   - If initialized with `Object`
+     - default `basePath` is empty String (`''`)
+     - any explicit `basePath` will be used as `basePath`
+   - In case when the resource path is an absolute URL, `basePath` is disregarded and only the URL is used to fetch the resource.
+   - Examples 
+     - `datapackage` is initialized with the `my-datapackages/datapackage.json` descriptor, the `basePath` is set to `data/` and the resource path is `november/resource.csv` the resource is expected to be in `my-datapackages/data/november/resource.cvs` relative of the directory where the library is executed.
 
 ###Class methods
 

--- a/data/dp4-remote-resource/data/data.csv
+++ b/data/dp4-remote-resource/data/data.csv
@@ -1,0 +1,4 @@
+name,size
+gb,105
+us,205
+cn,305

--- a/data/dp4-remote-resource/datapackage.json
+++ b/data/dp4-remote-resource/datapackage.json
@@ -17,6 +17,23 @@
           }
         ]
       }
+    },
+    {
+      "name": "random",
+      "format": "csv",
+      "path": "data.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "size",
+            "type": "number"
+          }
+        ]
+      }
     }
   ],
   "views": [

--- a/data/dp4-remote-resource/datapackage.json
+++ b/data/dp4-remote-resource/datapackage.json
@@ -1,0 +1,43 @@
+{
+  "name": "abc",
+  "resources": [
+    {
+      "name": "random",
+      "format": "csv",
+      "path": "https://raw.githubusercontent.com/frictionlessdata/datapackage-js/master/data/dp1/datapackage.json",
+      "schema": {
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "size",
+            "type": "number"
+          }
+        ]
+      }
+    }
+  ],
+  "views": [
+    {
+      "type": "vegalite",
+      "spec": {
+        "data": {
+          "resource": "random"
+        },
+        "mark": "bar",
+        "encoding": {
+          "x": {
+            "field": "name",
+            "type": "ordinal"
+          },
+          "y": {
+            "field": "size",
+            "type": "quantitative"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/datapackage.js
+++ b/src/datapackage.js
@@ -190,7 +190,7 @@ export default class DataPackage {
     const resourceObject = new Resource(resource, this._basePath)
 
     let pathErrors = []
-    if (resourceObject.typeOfResourcePath !== 'inline') {
+    if (resourceObject.type !== 'inline') {
       try {
         const valid = resourceObject._validPaths
       } catch (err) {

--- a/src/datapackage.js
+++ b/src/datapackage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import path from 'path'
+import url from 'url'
 import Utils from './utils'
 import Resource from './resource'
 import Profiles from './profiles'
@@ -14,16 +15,19 @@ export default class DataPackage {
   /**
    * Returns a Promise that will resolve in Datapackage instance.
    *
-   * @param {Object|String} descriptor - A datapackage descriptor Object or an URI string
+   * @param {Object|String} descriptor - A datapackage descriptor Object or an
+   *   URI string
    * @param {Object|String} [profile='base'] - Profile to validate against
    * @param {Boolean} [raiseInvalid=true] - Throw errors if validation fails
    * @param {Boolean} [remoteProfiles=false] - Use remote profiles
-   * @param {String|path} [basePath=null] - Base path for the resources. If the provided
-   * descriptor is a local path to a file, the default value is the dirname of the path.
+   * @param {String} [basePath=''] - Base path for the resources. If the
+   *   provided descriptor is a local path to a file, the default value is the
+   *   dirname of the path.
    * @return {Promise} - Resolves in class instance or rejects with errors
+   * @throws Array of errors if raiseInvalid is true and basePath contains illegal characters
    */
   constructor(descriptor, profile = 'base', raiseInvalid = true,
-    remoteProfiles = false, basePath) {
+    remoteProfiles = false, basePath = '') {
 
     const self = this
 
@@ -31,7 +35,14 @@ export default class DataPackage {
       self._profile = profile
       self._raiseInvalid = raiseInvalid
       self._remoteProfiles = remoteProfiles
-      self._basePath = basePath || DataPackage._getBasePath(descriptor)
+
+      // Check if basePath is valid and throw error if needed
+      const basePathErrors = Utils.checkPath(basePath)
+      const basePathValid = basePathErrors.length === 0
+      if (self._shouldRaise(basePathValid)) throw basePathErrors
+      self._valid = basePathValid
+      self._errors = this.errors.concat(basePathErrors)
+      self._basePath = DataPackage._getBasePath(descriptor, basePath)
 
       new Profiles(self._remoteProfiles).then(profilesInstance => {
         self._Profiles = profilesInstance
@@ -88,7 +99,8 @@ export default class DataPackage {
   /**
    * Updates the current descriptor with the properties of the provided Object.
    * New properties are added and existing properties are replaced.
-   * Note: it doesn't do deep merging, it just adds/replaces top level properties
+   * Note: it doesn't do deep merging, it just adds/replaces top level
+   * properties
    *
    * @param {Object} newDescriptor
    * @return {Boolean} - Returns validation status of the package
@@ -111,9 +123,10 @@ export default class DataPackage {
   }
 
   /**
-   * Adds new resource to the datapackage and triggers validation of the datapackage.
-   * When adding a resource that is already present in the datapackage, the
-   * provided resource will be omitted and the return value will be `true`.
+   * Adds new resource to the datapackage and triggers validation of the
+   * datapackage. When adding a resource that is already present in the
+   * datapackage, the provided resource will be omitted and the return value
+   * will be `true`.
    *
    * @param descriptor {Object}
    * @returns {Boolean} - Returns validation status of the package
@@ -121,7 +134,7 @@ export default class DataPackage {
    * raiseInvalid is `true` or descriptor argument is not an Object
    */
   addResource(descriptor) {
-    if (_.isObject(descriptor) && !_.isFunction(descriptor)) {
+    if (_.isObject(descriptor) && !_.isFunction(descriptor) && !_.isArray(descriptor)) {
       const newResource = new Resource(descriptor, this._basePath)
       const resourceFound = _.find(
         this.resources, resource => _.isEqual(resource, newResource))
@@ -154,13 +167,43 @@ export default class DataPackage {
    * @private
    */
   _validateDescriptor(descriptor, profile) {
-    const validation = this._Profiles.validate(descriptor, profile)
-    const validationError = validation instanceof Array
+    const descriptorErrors = this._Profiles.validate(descriptor, profile)
+    const descriptorValid = descriptorErrors.length === 0
 
-    this._errors = validationError ? validation : []
-    this._valid = !validationError
+    this._errors = descriptorErrors
+    this._valid = descriptorValid
 
-    return this._valid
+    _.forEach(descriptor.resources, resource => {
+      this._valid = this.valid && this._validateResource(resource)
+    })
+
+    return this.valid
+  }
+
+  /**
+   * Validate a resource descriptor. It returns the validity of the resource
+   * and store any errors in this._errors.
+   *
+   * @param {Object} resource
+   * @return {boolean}
+   * @private
+   */
+  _validateResource(resource) {
+    const resourceObject = new Resource(resource, this._basePath)
+
+    let pathErrors = []
+    if (resourceObject.typeOfResourcePath !== 'inline') {
+      try {
+        const valid = resourceObject._validPaths
+      } catch (err) {
+        pathErrors = err
+      }
+    }
+
+    const pathValid = pathErrors.length === 0
+    this._errors = this._errors.concat(pathErrors)
+
+    return pathValid
   }
 
   /**
@@ -237,18 +280,19 @@ export default class DataPackage {
    * local path, or the URL if the datapackage was loaded via URL.
    *
    * @param {String} descriptor
+   * @param {String} basePath
    * @return {String|null}
    * @private
    */
-  static _getBasePath(descriptor) {
+  static _getBasePath(descriptor, basePath = '') {
     if (typeof descriptor === 'string') {
-      if (!Utils.isRemoteURL(descriptor)) {
-        return path.dirname(descriptor)
+      if (Utils.isRemoteURL(descriptor)) {
+        return url.resolve(descriptor, basePath)
       }
 
-      return descriptor
+      return path.join(path.dirname(descriptor), basePath)
     }
 
-    return null
+    return basePath
   }
 }

--- a/src/datapackage.js
+++ b/src/datapackage.js
@@ -39,9 +39,7 @@ export default class DataPackage {
       // Check if basePath is valid and throw error if needed
       const basePathErrors = Utils.checkPath(basePath)
       const basePathValid = basePathErrors.length === 0
-      if (self._shouldRaise(basePathValid)) throw basePathErrors
-      self._valid = basePathValid
-      self._errors = this.errors.concat(basePathErrors)
+      if (!basePathValid) throw basePathErrors
       self._basePath = DataPackage._getBasePath(descriptor, basePath)
 
       new Profiles(self._remoteProfiles).then(profilesInstance => {

--- a/src/datapackage.js
+++ b/src/datapackage.js
@@ -245,6 +245,8 @@ export default class DataPackage {
       if (!Utils.isRemoteURL(descriptor)) {
         return path.dirname(descriptor)
       }
+
+      return descriptor
     }
 
     return null

--- a/src/datapackage.js
+++ b/src/datapackage.js
@@ -166,10 +166,12 @@ export default class DataPackage {
    */
   _validateDescriptor(descriptor, profile) {
     const descriptorErrors = this._Profiles.validate(descriptor, profile)
-    const descriptorValid = descriptorErrors.length === 0
-
-    this._errors = descriptorErrors
-    this._valid = descriptorValid
+    if (descriptorErrors instanceof Array) {
+      this._errors = descriptorErrors
+      this._valid = false
+    } else {
+      this._valid = true
+    }
 
     _.forEach(descriptor.resources, resource => {
       this._valid = this.valid && this._validateResource(resource)
@@ -199,7 +201,7 @@ export default class DataPackage {
     }
 
     const pathValid = pathErrors.length === 0
-    this._errors = this._errors.concat(pathErrors)
+    this._errors = this.errors.concat(pathErrors)
 
     return pathValid
   }

--- a/src/datapackage.js
+++ b/src/datapackage.js
@@ -234,7 +234,7 @@ export default class DataPackage {
 
   /**
    * Returns the basepath from the path of the current descriptor if it is a
-   * local path.
+   * local path, or the URL if the datapackage was loaded via URL.
    *
    * @param {String} descriptor
    * @return {String|null}

--- a/src/datapackage.js
+++ b/src/datapackage.js
@@ -31,7 +31,7 @@ export default class DataPackage {
       self._profile = profile
       self._raiseInvalid = raiseInvalid
       self._remoteProfiles = remoteProfiles
-      self._basePath = basePath || self._getBasePath(descriptor)
+      self._basePath = basePath || DataPackage._getBasePath(descriptor)
 
       new Profiles(self._remoteProfiles).then(profilesInstance => {
         self._Profiles = profilesInstance
@@ -240,7 +240,7 @@ export default class DataPackage {
    * @return {String|null}
    * @private
    */
-  _getBasePath(descriptor) {
+  static _getBasePath(descriptor) {
     if (typeof descriptor === 'string') {
       if (!Utils.isRemoteURL(descriptor)) {
         return path.dirname(descriptor)

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -62,8 +62,8 @@ export default class Profiles {
    * @param {Object} descriptor The descriptor that needs to be validated
    * @param {Object|String} profile Schema to validate against, could be ID of a
    * profile or profile Object
-   * @return {true|Array} Resolves `true` or array of strings which explain the
-   *   errors.
+   * @return {Array} Empty array or array of errors found
+   *
    */
   validate(descriptor, profile = 'base') {
     function _tv4validation(data, schema) {
@@ -73,7 +73,7 @@ export default class Profiles {
 
       const validation = tv4.validateMultiple(data, schema)
       if (validation.valid) {
-        return true
+        return []
       }
 
       return Utils.errorsToStringArray(validation.errors)

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -73,7 +73,7 @@ export default class Profiles {
 
       const validation = tv4.validateMultiple(data, schema)
       if (validation.valid) {
-        return []
+        return true
       }
 
       return Utils.errorsToStringArray(validation.errors)

--- a/src/resource.js
+++ b/src/resource.js
@@ -80,7 +80,7 @@ export default class Resource {
       return source
 
     } else if (this._sourceKey === 'path' && this._basePath === '') {
-      // Local path, no basePath provided
+      // Local or remote path, no basePath provided
       if (this._validPaths) {
         return source
       }
@@ -92,6 +92,8 @@ export default class Resource {
       if (this._validPaths) {
         if (Utils.isRemoteURL(this._basePath)) {
           // basePath is remote URL
+          // in case when `source` is an absolute url, url.resolve returns only `source`
+
           return url.resolve(this._basePath, source)
 
         }

--- a/src/resource.js
+++ b/src/resource.js
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import path from 'path'
 import jts from 'jsontableschema'
 
+import Utils from './utils'
 
 // Module API
 
@@ -73,6 +74,10 @@ export default class Resource {
   get source() {
     if (this._sourceKey === 'path' && this._basePath) {
       const resourcePath = this.descriptor[this._sourceKey]
+      if (Utils.isRemoteURL(this._basePath)) {
+        return url.resolve(this._basePath, resourcePath)
+      }
+
       return path.normalize(`${this._basePath}/${resourcePath}`)
     }
 

--- a/src/resource.js
+++ b/src/resource.js
@@ -45,7 +45,7 @@ export default class Resource {
    *
    * @returns {String}
    */
-  get typeOfResourcePath() {
+  get type() {
     if (this._sourceKey === 'data') {
       return 'inline'
     }
@@ -75,7 +75,7 @@ export default class Resource {
       // Neither inline data nor path available
       return null
 
-    } else if (this.typeOfResourcePath === 'inline') {
+    } else if (this.type === 'inline') {
       // Data is inline
       return source
 

--- a/src/resource.js
+++ b/src/resource.js
@@ -72,16 +72,19 @@ export default class Resource {
    * @returns {String|Array|Object}
    */
   get source() {
-    if (this._sourceKey === 'path' && this._basePath) {
-      const resourcePath = this.descriptor[this._sourceKey]
+    const source = this.descriptor[this._sourceKey]
+
+    if (this._sourceKey === 'path' && this._basePath
+        && !Utils.isRemoteURL(source)) {
+
       if (Utils.isRemoteURL(this._basePath)) {
-        return url.resolve(this._basePath, resourcePath)
+        return url.resolve(this._basePath, source)
       }
 
-      return path.normalize(`${this._basePath}/${resourcePath}`)
+      return path.normalize(`${this._basePath}/${source}`)
     }
 
-    return this.descriptor[this._sourceKey]
+    return source
   }
 
   /**

--- a/test/datapackage.js
+++ b/test/datapackage.js
@@ -185,6 +185,18 @@ describe('Datapackage', () => {
     })
   })
 
+  describe('remote datapackage', () => {
+    it('reads the resource', async () => {
+      const descriptor = 'https://raw.githubusercontent.com/frictionlessdata/datapackage-js/master/data/dp1/datapackage.json'
+
+      const datapackage = await new Datapackage(descriptor)
+      const table2 = await datapackage.resources[0].table
+      const data = await table2.read()
+
+      assert(_.isEqual(data, [['gb', 100], ['us', 200], ['cn', 300]]), 'Invalid data.')
+    })
+  })
+
   describe('README', () => {
     const testDatapackage = 'http://bit.do/datapackage-json'
 

--- a/test/datapackage.js
+++ b/test/datapackage.js
@@ -14,7 +14,6 @@ describe('Datapackage', () => {
     it('initializes with Object descriptor', async () => {
       const dp1 = fs.readFileSync('data/dp1/datapackage.json', 'utf8')
       const datapackage = await new Datapackage(JSON.parse(dp1))
-
       assert(_.isEqual(datapackage.descriptor, JSON.parse(dp1)),
           'Datapackage descriptor not equal the provided descriptor')
     })
@@ -184,32 +183,67 @@ describe('Datapackage', () => {
       assert(datapackage.resources.length === 2, 'New resource not added to datapackge')
       assert(_.isEqual(data, expectedData), 'Wrong data loaded')
     })
+
+    it('resource.table throws an Array of errors if resource path is illegal and raiseInvalid is true', async () => {
+      const datapackage = await new Datapackage(
+        'data/dp2-tabular/datapackage.json', 'tabular', false, false)
+      const newResource = datapackage.resources[0]
+      newResource.path = 'illegal/../../../path'
+      datapackage.addResource(newResource)
+
+      assert.throws(() => datapackage.resources[1].table, Array, /illegal/)
+    })
   })
 
   describe('#_getBasePath', () => {
     it('returns the URL if the datapackage descriptor is URL', async () => {
-      const remoteURL = 'http://bit.do/datapackage-json'
+      const remoteURL = 'http://bit.do/datapackage.json'
       assert(Datapackage._getBasePath(remoteURL) === remoteURL)
+    })
+
+    it('returns appended URL with explicitly provided basePath', async () => {
+      const remoteURL = 'http://example.datapackage.url/datapackage.json'
+      const basePath = 'datapackage/url'
+      const expectedURL = 'http://example.datapackage.url/datapackage/url'
+      assert(Datapackage._getBasePath(remoteURL, basePath) === expectedURL)
     })
 
     it('returns the dirname if the datapackage descriptor is local path', async () => {
       const localPath = 'path/to/datapackage.json'
-      assert(Datapackage._getBasePath(localPath) === path.dirname(localPath))
+      const expectedPath = 'path/to'
+      assert(Datapackage._getBasePath(localPath) === expectedPath)
+    })
+
+    it('returns appended local path with the explicitly provided basePath', () => {
+      const localPath = 'path/to/datapackage.json'
+      const basePath = 'collected/data/'
+      const expectedPath = 'path/to/collected/data/'
+      assert(Datapackage._getBasePath(localPath, basePath) === expectedPath)
+    })
+
+    it('returns zero length string if provided argument is not string', () => {
+      const emptyObject = {}
+      assert(Datapackage._getBasePath(emptyObject) === '')
+    })
+
+    it('returns the basePath if the datapackage descriptor is Object', () => {
+      const basePath = 'collected/data/'
+      const expectedPath = 'collected/data/'
+      assert(Datapackage._getBasePath({}, basePath) === expectedPath)
     })
   })
 
-  describe('remote datapackage resources', () => {
-    it('relative resource', async () => {
+  describe('datapackages with remote resources', () => {
+    it('loads relative resource', async () => {
       const descriptor = 'https://raw.githubusercontent.com/frictionlessdata/datapackage-js/master/data/dp1/datapackage.json'
 
       const datapackage = await new Datapackage(descriptor)
       const table = await datapackage.resources[0].table
       const data = await table.read()
-
       assert(_.isEqual(data, [['gb', 100], ['us', 200], ['cn', 300]]), 'Invalid data.')
     })
 
-    it('URL resource', async () => {
+    it('loads resource from absolute URL', async () => {
       const descriptor = 'https://dev.keitaro.info/dpkjs/datapackage.json'
 
       const datapackage = await new Datapackage(descriptor)
@@ -217,6 +251,53 @@ describe('Datapackage', () => {
       const data = await table.read()
 
       assert(_.isEqual(data, [['gb', 100], ['us', 200], ['cn', 300]]), 'Invalid data.')
+    })
+
+    it('loads resource from absolute URL disregarding basePath', async () => {
+      const descriptor = 'https://dev.keitaro.info/dpkjs/datapackage.json'
+
+      const datapackage = await new Datapackage(descriptor, 'base', true, false, 'local/basePath')
+      const table = await datapackage.resources[0].table
+      const data = await table.read()
+
+      assert(_.isEqual(data, [['gb', 100], ['us', 200], ['cn', 300]]), 'Invalid data.')
+    })
+
+    it('loads remote resource with basePath', async () => {
+      const descriptor = 'https://dev.keitaro.info/dpkjs/datapackage.json'
+
+      const datapackage = await new Datapackage(descriptor, 'base', true, false, 'data/')
+      const table = await datapackage.resources[1].table
+      const data = await table.read()
+
+      assert(_.isEqual(data, [['gb', 105], ['us', 205], ['cn', 305]]), 'Invalid data.')
+    })
+  })
+
+  describe('basePath', () => {
+    const descriptor = 'data/dp1/datapackage.json'
+
+    it('appends explicitly provided basePath to the datapackage.json path', async () => {
+      const datapackage = await new Datapackage(descriptor, 'base', false, false, 'data/')
+      assert(datapackage._basePath === 'data/dp1/data/', 'basePath not appended')
+    })
+
+    it('doesn\'t allow using relative parent path in basePath if explicitly provided', () => {
+      new Datapackage(descriptor, 'base', true, false, 'data/../').then(() => {
+        assert(false, 'Error not thrown')
+      }, err => {
+        assert(err instanceof Array)
+        assert(err[0] = 'Found illegal \'..\' in data/../')
+      })
+    })
+
+    it('doesn\'t allow using relative parent path in resource path', async () => {
+      const datapackage = await new Datapackage(descriptor)
+      const dp2descriptor = fs.readFileSync('data/dp2-tabular/datapackage.json', 'utf8')
+      const newResource = JSON.parse(dp2descriptor).resources[0]
+      newResource.path = '../dp2-tabular/data.csv'
+
+      assert.throws(() => datapackage.addResource(newResource), Array)
     })
   })
 

--- a/test/datapackage.js
+++ b/test/datapackage.js
@@ -185,13 +185,23 @@ describe('Datapackage', () => {
     })
   })
 
-  describe('remote datapackage', () => {
-    it('reads the resource', async () => {
+  describe('remote datapackage resources', () => {
+    it('relative resource', async () => {
       const descriptor = 'https://raw.githubusercontent.com/frictionlessdata/datapackage-js/master/data/dp1/datapackage.json'
 
       const datapackage = await new Datapackage(descriptor)
-      const table2 = await datapackage.resources[0].table
-      const data = await table2.read()
+      const table = await datapackage.resources[0].table
+      const data = await table.read()
+
+      assert(_.isEqual(data, [['gb', 100], ['us', 200], ['cn', 300]]), 'Invalid data.')
+    })
+
+    it.only('URL resource', async () => {
+      const descriptor = 'https://dev.keitaro.info/dpkjs/datapackage.json'
+
+      const datapackage = await new Datapackage(descriptor)
+      const table = await datapackage.resources[0].table
+      const data = await table.read()
 
       assert(_.isEqual(data, [['gb', 100], ['us', 200], ['cn', 300]]), 'Invalid data.')
     })

--- a/test/datapackage.js
+++ b/test/datapackage.js
@@ -1,5 +1,6 @@
 import 'babel-polyfill'
 import fs from 'fs'
+import path from 'path'
 import { assert } from 'chai'
 import _ from 'lodash'
 import parse from 'csv-parse/lib/sync'
@@ -185,6 +186,18 @@ describe('Datapackage', () => {
     })
   })
 
+  describe('#_getBasePath', () => {
+    it('returns the URL if the datapackage descriptor is URL', async () => {
+      const remoteURL = 'http://bit.do/datapackage-json'
+      assert(Datapackage._getBasePath(remoteURL) === remoteURL)
+    })
+
+    it('returns the dirname if the datapackage descriptor is local path', async () => {
+      const localPath = 'path/to/datapackage.json'
+      assert(Datapackage._getBasePath(localPath) === path.dirname(localPath))
+    })
+  })
+
   describe('remote datapackage resources', () => {
     it('relative resource', async () => {
       const descriptor = 'https://raw.githubusercontent.com/frictionlessdata/datapackage-js/master/data/dp1/datapackage.json'
@@ -196,7 +209,7 @@ describe('Datapackage', () => {
       assert(_.isEqual(data, [['gb', 100], ['us', 200], ['cn', 300]]), 'Invalid data.')
     })
 
-    it.only('URL resource', async () => {
+    it('URL resource', async () => {
       const descriptor = 'https://dev.keitaro.info/dpkjs/datapackage.json'
 
       const datapackage = await new Datapackage(descriptor)

--- a/test/profiles.js
+++ b/test/profiles.js
@@ -62,7 +62,7 @@ describe('Profiles', () => {
          assert(profiles.validate(descriptor) instanceof Array)
        })
 
-    it('returns true for valid data and schema passed as argument',
+    it('returns empty Array for valid data and schema passed as argument',
        async () => {
          const schema = fs.readFileSync('src/schemas/tabular-data-package.json')
          const descriptor = fs.readFileSync('data/dp2-tabular/datapackage.json', 'utf8')
@@ -70,7 +70,7 @@ describe('Profiles', () => {
          const descriptorObject = JSON.parse(descriptor)
          const profiles = await new Profiles(false)
 
-         assert(profiles.validate(descriptorObject, schemaObject) === true)
+         assert(profiles.validate(descriptorObject, schemaObject).length === 0)
        })
   })
 

--- a/test/profiles.js
+++ b/test/profiles.js
@@ -44,7 +44,7 @@ describe('Profiles', () => {
       const profiles = await new Profiles(false)
       const datapackage = fs.readFileSync('data/dp1/datapackage.json', 'utf8')
 
-      assert(profiles.validate(datapackage))
+      assert(profiles.validate(JSON.parse(datapackage)) === true)
     })
 
     it('returns array of lint errors for invalid json string', async () => {
@@ -62,7 +62,7 @@ describe('Profiles', () => {
          assert(profiles.validate(descriptor) instanceof Array)
        })
 
-    it('returns empty Array for valid data and schema passed as argument',
+    it('returns true for valid data and schema passed as argument',
        async () => {
          const schema = fs.readFileSync('src/schemas/tabular-data-package.json')
          const descriptor = fs.readFileSync('data/dp2-tabular/datapackage.json', 'utf8')
@@ -70,7 +70,7 @@ describe('Profiles', () => {
          const descriptorObject = JSON.parse(descriptor)
          const profiles = await new Profiles(false)
 
-         assert(profiles.validate(descriptorObject, schemaObject).length === 0)
+         assert(profiles.validate(descriptorObject, schemaObject) === true)
        })
   })
 

--- a/test/resource.js
+++ b/test/resource.js
@@ -45,20 +45,20 @@ describe('Resource', () => {
     assert(resource.name === resourceDesc.name, 'Invalid name')
   })
 
-  it('recognizes that data typeOfResourcePath is local', () => {
+  it('recognizes that data type is local', () => {
     const resouceDesc = {
       path: 'foo/bar.txt',
     }
     const resource = new Resource(resouceDesc)
-    assert(resource.typeOfResourcePath === 'local', 'Invalid data typeOfResourcePath')
+    assert(resource.type === 'local', 'Invalid data type')
   })
 
-  it('recognizes that data typeOfResourcePath is remote', () => {
+  it('recognizes that data type is remote', () => {
     const resouceDesc = {
       path: 'http://www.foo.org/bar.txt',
     }
     const resource = new Resource(resouceDesc)
-    assert(resource.typeOfResourcePath === 'remote', 'Invalid data typeOfResourcePath')
+    assert(resource.type === 'remote', 'Invalid data type')
   })
 
   it('recognizes that data is inline', () => {
@@ -66,7 +66,7 @@ describe('Resource', () => {
       data: 'foo, bar',
     }
     const resource = new Resource(resouceDesc)
-    assert(resource.typeOfResourcePath === 'inline', 'Inline data not found')
+    assert(resource.type === 'inline', 'Inline data not found')
   })
 
   it('table getter returns jts.Table', async () => {
@@ -231,9 +231,9 @@ describe('Resource', () => {
          }
        })
 
-    it('returns \'local\' typeOfResourcePath', () => {
+    it('returns \'local\' type', () => {
       const resource = new Resource(dp1.resources[0])
-      assert(resource.typeOfResourcePath === 'local', 'Incorrect typeOfResourcePath for datapackage')
+      assert(resource.type === 'local', 'Incorrect type for datapackage')
     })
   })
 
@@ -263,7 +263,7 @@ describe('Resource', () => {
       }
       const resource = new Resource({ data: resourceData, schema: resourceSchema })
 
-      assert(resource.typeOfResourcePath === 'inline', 'Data typeOfResourcePath not inline')
+      assert(resource.type === 'inline', 'Data type not inline')
       assert(resource.source === resourceData)
     })
   })

--- a/test/resource.js
+++ b/test/resource.js
@@ -1,6 +1,7 @@
 import 'babel-polyfill'
 import _ from 'lodash'
 import path from 'path'
+import url from 'url'
 import { assert } from 'chai'
 import jts from 'jsontableschema'
 import { Resource } from '../src/index'
@@ -108,6 +109,41 @@ describe('Resource', () => {
       const source = resource._basePath
 
       assert(source === null, 'basePath not `null`')
+    })
+  })
+
+  describe('#source', () => {
+    it('returns correct relative path for local resource', async () => {
+      const resourcePath = 'dataFolder/data.csv'
+      const basePath = 'path/to/datapackage/'
+
+      const resource = new Resource({
+        path: resourcePath,
+      }, basePath)
+
+      assert(resource.source === path.normalize(`${basePath}/${resourcePath}`))
+    })
+
+    it('returns correct relative path for remote resource', async () => {
+      const resourcePath = 'dataFolder/data.csv'
+      const baseURL = 'http://remote.path.to/datapackage.json'
+
+      const resource = new Resource({
+        path: resourcePath,
+      }, baseURL)
+
+      assert(resource.source === url.resolve(baseURL, resourcePath))
+    })
+
+    it('returns just the resource path if there is not basePath specified', async () => {
+      const resourcePath = 'dataFolder/data.csv'
+      const basePath = null
+
+      const resource = new Resource({
+        path: resourcePath,
+      }, basePath)
+
+      assert(resource.source === resourcePath)
     })
   })
 

--- a/test/resource.js
+++ b/test/resource.js
@@ -26,7 +26,7 @@ describe('Resource', () => {
   it('contains no source by default', () => {
     const resourceDesc = {}
     const resource = new Resource(resourceDesc)
-    assert(resource.source === undefined, 'Invalid source')
+    assert(resource.source === null, 'Invalid source')
   })
 
   it('returns the expected test data', () => {
@@ -45,20 +45,20 @@ describe('Resource', () => {
     assert(resource.name === resourceDesc.name, 'Invalid name')
   })
 
-  it('recognizes that data type is local', () => {
+  it('recognizes that data typeOfResourcePath is local', () => {
     const resouceDesc = {
       path: 'foo/bar.txt',
     }
     const resource = new Resource(resouceDesc)
-    assert(resource.type === 'local', 'Invalid data type')
+    assert(resource.typeOfResourcePath === 'local', 'Invalid data typeOfResourcePath')
   })
 
-  it('recognizes that data type is remote', () => {
+  it('recognizes that data typeOfResourcePath is remote', () => {
     const resouceDesc = {
       path: 'http://www.foo.org/bar.txt',
     }
     const resource = new Resource(resouceDesc)
-    assert(resource.type === 'remote', 'Invalid data type')
+    assert(resource.typeOfResourcePath === 'remote', 'Invalid data typeOfResourcePath')
   })
 
   it('recognizes that data is inline', () => {
@@ -66,7 +66,7 @@ describe('Resource', () => {
       data: 'foo, bar',
     }
     const resource = new Resource(resouceDesc)
-    assert(resource.type === 'inline', 'Inline data not found')
+    assert(resource.typeOfResourcePath === 'inline', 'Inline data not found')
   })
 
   it('table getter returns jts.Table', async () => {
@@ -104,11 +104,11 @@ describe('Resource', () => {
       assert(path.dirname(resourceBasePath) === path.normalize(basePath), 'Incorrect base path')
     })
 
-    it('_basePath is `null` if basePath argument is not provided', () => {
+    it('_basePath is empty string if basePath argument is not provided', () => {
       const resource = new Resource({})
       const source = resource._basePath
 
-      assert(source === null, 'basePath not `null`')
+      assert(source === '', 'basePath not empty string')
     })
   })
 
@@ -116,34 +116,56 @@ describe('Resource', () => {
     it('returns correct relative path for local resource', async () => {
       const resourcePath = 'dataFolder/data.csv'
       const basePath = 'path/to/datapackage/'
+      const expectedPath = 'path/to/datapackage/dataFolder/data.csv'
 
       const resource = new Resource({
         path: resourcePath,
       }, basePath)
 
-      assert(resource.source === path.normalize(`${basePath}/${resourcePath}`))
+      assert(resource.source === expectedPath)
     })
 
     it('returns correct relative path for remote resource', async () => {
       const resourcePath = 'dataFolder/data.csv'
       const baseURL = 'http://remote.path.to/datapackage.json'
+      const expectedURL = 'http://remote.path.to/dataFolder/data.csv'
 
       const resource = new Resource({
         path: resourcePath,
       }, baseURL)
 
-      assert(resource.source === url.resolve(baseURL, resourcePath))
+      assert(resource.source === expectedURL)
     })
 
     it('returns just the resource path if there is not basePath specified', async () => {
       const resourcePath = 'dataFolder/data.csv'
-      const basePath = null
 
       const resource = new Resource({
         path: resourcePath,
-      }, basePath)
+      })
 
       assert(resource.source === resourcePath)
+    })
+
+    it('doesn\'t allow reading file which has illegal path', async () => {
+      const illegalPaths = ['../data.csv', '/data.csv', 'data/.\\./data.csv', 'data/../../data.csv']
+      _.forEach(illegalPaths, resourcePath => {
+        try {
+          const resource = new Resource({
+            path: resourcePath,
+          })
+
+          const source = resource.source
+          assert(false, `Error for ${resourcePath} not thrown`)
+        } catch (err) {
+          assert(err instanceof Array, 'Error thrown is not an Array')
+          assert(err.length > 0, 'Length of thrown array whould be greater then 0')
+        }
+      })
+    })
+
+    it('doesn\'t allo wreading file which has illegal basePath', async () => {
+
     })
   })
 
@@ -209,9 +231,9 @@ describe('Resource', () => {
          }
        })
 
-    it('returns \'local\' type', () => {
+    it('returns \'local\' typeOfResourcePath', () => {
       const resource = new Resource(dp1.resources[0])
-      assert(resource.type === 'local', 'Incorrect type for datapackage')
+      assert(resource.typeOfResourcePath === 'local', 'Incorrect typeOfResourcePath for datapackage')
     })
   })
 
@@ -241,7 +263,7 @@ describe('Resource', () => {
       }
       const resource = new Resource({ data: resourceData, schema: resourceSchema })
 
-      assert(resource.type === 'inline', 'Data type not inline')
+      assert(resource.typeOfResourcePath === 'inline', 'Data typeOfResourcePath not inline')
       assert(resource.source === resourceData)
     })
   })

--- a/test/validate.js
+++ b/test/validate.js
@@ -7,33 +7,33 @@ import { validate } from '../src/index'
 
 describe('#Validate', () => {
   describe('Using local profiles', () => {
-    it('returns true for valid descriptor', async () => {
+    it('returns empty Array for valid descriptor', async () => {
       const dp1 = fs.readFileSync('data/dp1/datapackage.json', 'utf8')
       const validation = await validate(JSON.parse(dp1))
 
-      assert(validation === true)
+      assert(validation.length === 0)
     })
 
     it('returns array of errors for invalid descriptor', async () => {
       const validation = await validate({})
 
-      assert(validation instanceof Array)
+      assert(validation.length > 0)
     })
   })
 
   describe('Using remote profiles', () => {
-    it('returns true for valid datapackage with tabular resources', async () => {
+    it('returns empty Array for valid datapackage with tabular resources', async () => {
       const dp2 = fs.readFileSync('data/dp2-tabular/datapackage.json', 'utf8')
       const validation = await validate(JSON.parse(dp2), 'tabular', true)
 
-      assert(validation === true)
+      assert(validation.length === 0)
     })
 
-    it('returns Array of Errors when using wrong profile', async () => {
+    it('returns Array with Errors when using wrong profile', async () => {
       const dp2 = fs.readFileSync('data/dp2-tabular/datapackage.json', 'utf8')
       const validation = await validate(JSON.parse(dp2), 'fiscal', true)
 
-      assert(validation instanceof Array)
+      assert(validation.length > 0)
     })
 
     it('returns Array of Errors when using not existing profile', async () => {

--- a/test/validate.js
+++ b/test/validate.js
@@ -7,11 +7,11 @@ import { validate } from '../src/index'
 
 describe('#Validate', () => {
   describe('Using local profiles', () => {
-    it('returns empty Array for valid descriptor', async () => {
+    it('returns true for valid descriptor', async () => {
       const dp1 = fs.readFileSync('data/dp1/datapackage.json', 'utf8')
       const validation = await validate(JSON.parse(dp1))
 
-      assert(validation.length === 0)
+      assert(validation === true)
     })
 
     it('returns array of errors for invalid descriptor', async () => {
@@ -22,11 +22,11 @@ describe('#Validate', () => {
   })
 
   describe('Using remote profiles', () => {
-    it('returns empty Array for valid datapackage with tabular resources', async () => {
+    it('returns true for valid datapackage with tabular resources', async () => {
       const dp2 = fs.readFileSync('data/dp2-tabular/datapackage.json', 'utf8')
       const validation = await validate(JSON.parse(dp2), 'tabular', true)
 
-      assert(validation.length === 0)
+      assert(validation === true)
     })
 
     it('returns Array with Errors when using wrong profile', async () => {


### PR DESCRIPTION
- fixes #41 
- fixes #52

---

Resolves #41 by adding `basePath` for remote datapackages and after that using `url.resolve` in `Resources` class to point to the relative resource.