### PR TITLE
Make sure that schemas are fetched according to the `_remote` parameter as well

### DIFF
--- a/src/profiles.js
+++ b/src/profiles.js
@@ -126,7 +126,7 @@ export default class Profiles {
 
     let profilePath
 
-    if (Utils.isBrowser) {
+    if (Utils.isBrowser && !self._remote) {
       profilePath = profile.schema_path.split('.')[0]
     } else if (this._basePath && profile.schema_path) {
       profilePath = path.join(this._basePath, profile.schema_path)


### PR DESCRIPTION
When using it on OS-Packager it simply tries to fetch the schemas from a local file regardless of the `remote` parameter. This fix should address that.
Couldn't make the local tests fail (to reproduce) though.