### PR TITLE
relative schema/dialect are retrieved when remote

### DIFF
--- a/test/package.js
+++ b/test/package.js
@@ -98,6 +98,15 @@ describe('Package', () => {
       assert.deepEqual(data, [['gb', 105], ['us', 205], ['cn', 305]])
     })
 
+    it('remote_dereference', async () => {
+      const descriptor = 'https://raw.githubusercontent.com/frictionlessdata/datapackage-js/master/data/data-package-dereference.json'
+      const dataPackage = await Package.load(descriptor)
+      assert.deepEqual(dataPackage.descriptor.resources, [
+        {name: 'name1', data: ['data'], schema: {fields: [{name: 'name'}]}},
+        {name: 'name2', data: ['data'], dialect: {delimiter: ','}},
+      ].map(expandResource))
+    })
+
   })
 
   describe('#descriptor (retrieve)', () => {


### PR DESCRIPTION
# Overview

This PR proposes a quick fix to allow to retrieve relative external schema and dialects when using a remote basePath. This feature was identified as missing in the code in a TODO comment.

I added a test using an existing test datapackage but used it in a remote context.

Basically, if the basePath is a remotePath it is added to the path before trying to retrieve it.

All tests pass. 

---

Please preserve this line to notify @roll (maintainer of this repository)
